### PR TITLE
feat: support env_files runfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ Find more examples on how to use `bazel_env.bzl` in <https://github.com/hofbi/ba
 ## Usage
 
 See our [examples](./examples/) for how to use this with [rules_rust](https://github.com/bazelbuild/rules_rust) and [rules_rs](https://github.com/hermeticbuild/rules_rs).
+
+Use `env_directories` when a build script needs an environment variable that points at a dependency root directory.
+Use `env_directory_subpaths` with `env_directories` when the environment variable should point at a relative path under that dependency root.
+Use `env_files` when it needs an environment variable that points at one exact file such as a tool binary.

--- a/cargo_env/BUILD.bazel
+++ b/cargo_env/BUILD.bazel
@@ -1,4 +1,7 @@
 load("@bazel_lib//:bzl_library.bzl", "bzl_library")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load(":cargo_env.bzl", "cargo_env")
 
 exports_files([
     "template.env",
@@ -15,4 +18,42 @@ bzl_library(
         "@bazel_skylib//rules/directory:providers",
         "@rules_shell//shell:rules_bzl",
     ],
+)
+
+cargo_env(
+    name = "env_files_test_env",
+    testonly = True,
+    env_directories = {
+        "TEST_MAIN_REPO_DIR": ":env_files_test_main_repo_files",
+    },
+    env_directory_subpaths = {
+        "TEST_MAIN_REPO_DIR": "cargo_env",
+    },
+    env_files = {
+        "TEST_FILE": ":env_files_test_tool_data.txt",
+        "TEST_TOOL": ":env_files_test_tool",
+    },
+)
+
+filegroup(
+    name = "env_files_test_main_repo_files",
+    srcs = ["env_files_test_tool_data.txt"],
+)
+
+sh_binary(
+    name = "env_files_test_tool",
+    srcs = ["env_files_test_tool.sh"],
+    data = ["env_files_test_tool_data.txt"],
+)
+
+sh_test(
+    name = "env_files_test",
+    srcs = ["env_files_test.sh"],
+    args = [
+        "$(location :env_files_test_env)",
+    ],
+    data = [
+        ":env_files_test_env",
+    ],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/cargo_env/cargo_env.bzl
+++ b/cargo_env/cargo_env.bzl
@@ -8,31 +8,78 @@ load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 def _is_file_type(path):
     return type(path) == "File"
 
-def _to_runfiles_path(path):
+def _to_runfiles_path(path, is_main_repo_file = False):
     """Convert execution-root path to runfiles-relative.
 
     Examples:
+    - foo -> _main/foo for files in the main repository
     - external/foo -> foo for external repositories
     - ../foo -> foo for generated files
     """
     if paths.starts_with(path, "external") or paths.starts_with(path, ".."):
         return path.split("/", 1)[-1]
+    if is_main_repo_file:
+        return paths.join("_main", path)
     return path
 
 def _make_abs_path(path):
     """Make a path absolute with $RUNFILES_DIR prefix, handling external repos."""
+    return paths.join("$RUNFILES_DIR", _make_runfiles_path(path))
+
+def _make_runfiles_path(path):
+    """Make a path relative to the runfiles root."""
+    is_main_repo_file = False
     if _is_file_type(path):
+        is_main_repo_file = path.owner and path.owner.workspace_root == ""
         path = path.path if path.is_source else path.short_path
     else:
         path = getattr(path, "path", path)
 
-    return paths.join("$RUNFILES_DIR", _to_runfiles_path(path))
+    return _to_runfiles_path(path, is_main_repo_file)
 
 def _make_include_arg(dir):
     return "-I" + _make_abs_path(dir[DirectoryInfo])
 
-def _make_custom_env_arg(item):
-    return "export {}=\"{}\"".format(item[0], _make_abs_path(item[1].label.workspace_root or "."))
+def _validate_relative_subpath(env_name, subpath):
+    if paths.is_absolute(subpath) or subpath == ".." or paths.starts_with(subpath, "../") or "/../" in subpath:
+        fail("env_directory_subpaths entry for {} must be a relative path within the env_directories target".format(env_name))
+
+def _make_directory_env_arg(item, subpaths):
+    env_name, target = item
+    path = target.label.workspace_root or "."
+    if env_name in subpaths:
+        subpath = subpaths[env_name]
+        _validate_relative_subpath(env_name, subpath)
+        if not target.label.workspace_root:
+            path = "_main"
+        path = paths.join(path, subpath)
+    return "export {}=\"{}\"".format(env_name, _make_abs_path(path))
+
+def _make_file_env_arg(item):
+    runfiles_path = _make_runfiles_path(item[1])
+    return "export {}=\"$(rlocation \"{}\" 2> /dev/null || printf '%s\\n' \"{}\")\"".format(
+        item[0],
+        runfiles_path,
+        paths.join("$RUNFILES_DIR", runfiles_path),
+    )
+
+def _get_env_file(target, env_name):
+    if DefaultInfo in target:
+        executable = target[DefaultInfo].files_to_run.executable
+        if executable:
+            return executable
+
+    files = target.files.to_list()
+    if len(files) != 1:
+        fail("env_files entry for {} must provide exactly one file, but {} files were found".format(env_name, len(files)))
+    return files[0]
+
+def _get_env_file_runfiles(targets):
+    runfiles = []
+    for target in targets:
+        if DefaultInfo in target:
+            runfiles.append(target[DefaultInfo].default_runfiles)
+    return runfiles
 
 def _get_optional(optional_file):
     return [optional_file] if optional_file else []
@@ -40,6 +87,10 @@ def _get_optional(optional_file):
 def _cargo_env_impl(ctx):
     output = ctx.actions.declare_file("%s.env" % ctx.attr.name)
     substitutions = ctx.actions.template_dict()
+
+    for env_name in ctx.attr.env_directory_subpaths:
+        if env_name not in ctx.attr.env_directories:
+            fail("env_directory_subpaths entry for {} must have a matching env_directories entry".format(env_name))
 
     substitutions.add_joined(
         "{INCLUDES}",
@@ -72,12 +123,18 @@ def _cargo_env_impl(ctx):
         map_each = _make_abs_path,
     )
 
-    substitutions.add_joined(
-        "{CUSTOM_ENV}",
-        depset(ctx.attr.env_directories.items()),
-        join_with = "\n",
-        map_each = _make_custom_env_arg,
-    )
+    env_file_entries = [
+        (env_name, _get_env_file(target, env_name))
+        for env_name, target in ctx.attr.env_files.items()
+    ]
+    custom_env = [
+        _make_directory_env_arg(item, ctx.attr.env_directory_subpaths)
+        for item in ctx.attr.env_directories.items()
+    ] + [
+        _make_file_env_arg(item)
+        for item in env_file_entries
+    ]
+    substitutions.add("{CUSTOM_ENV}", "\n".join(custom_env))
 
     ctx.actions.expand_template(
         output = output,
@@ -87,8 +144,10 @@ def _cargo_env_impl(ctx):
     )
 
     runfiles = ctx.runfiles(
-        files = ctx.files.include_directories + optional_clang + optional_libclang + optional_openssl_dir,
+        files = ctx.files.include_directories + optional_clang + optional_libclang + optional_openssl_dir + [file for _, file in env_file_entries],
         transitive_files = depset(transitive = [target.files for target in ctx.attr.env_directories.values()]),
+    ).merge_all(
+        _get_env_file_runfiles(ctx.attr.env_files.values()),
     )
 
     return [DefaultInfo(files = depset([output]), runfiles = runfiles)]
@@ -103,6 +162,16 @@ cargo_env = rule(
         "env_directories": attr.string_keyed_label_dict(
             default = {},
             doc = "Map of environment variable names to filegroup targets. The path will be the repo/package root of the target. Example: {\"MY_LIB_PATH\": \"@my_lib//:source_files\"}",
+        ),
+        "env_directory_subpaths": attr.string_dict(
+            default = {},
+            doc = "Map of env_directories environment variable names to relative subpaths under their target repository root. Example: {\"PROTOC_INCLUDE\": \"src\"}",
+        ),
+        "env_files": attr.string_keyed_label_dict(
+            allow_files = True,
+            cfg = "exec",
+            default = {},
+            doc = "Map of environment variable names to single file targets in the exec configuration. The path will be the file path. Example: {\"MY_TOOL\": \"@my_tool//:binary\"}",
         ),
         "include_directories": attr.label_list(
             default = [],
@@ -134,6 +203,12 @@ cargo_env = rule(
         openssl_dir = "@openssl//:gen_dir",
         env_directories = {
             "SOME_PACKAGE_PATH": "@some_package//:source_files",
+        },
+        env_directory_subpaths = {
+            "SOME_PACKAGE_PATH": "include",
+        },
+        env_files = {
+            "SOME_TOOL": "@some_tool//:binary",
         },
     )
     ```

--- a/cargo_env/env_files_test.sh
+++ b/cargo_env/env_files_test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Verifies that env_files entries export runnable runfiles paths.
+set -uo pipefail
+
+set +e
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck disable=SC1090
+# shuck: disable=C160
+source "${RUNFILES_DIR:-/dev/null}/$f" 2> /dev/null ||
+    source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2> /dev/null ||
+    # shuck: disable=C160
+    source "$0.runfiles/$f" 2> /dev/null ||
+    source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2> /dev/null ||
+    source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2> /dev/null ||
+    {
+        echo >&2 "ERROR: cannot find $f"
+        exit 1
+    }
+# shuck: disable=C159
+f=
+set -e
+
+set -o pipefail
+
+# shuck: disable=C002
+source "$1"
+
+[[ -x "${TEST_TOOL}" ]]
+[[ "$("${TEST_TOOL}")" == "env_files_test_tool" ]]
+[[ "$(cat "${TEST_FILE}")" == "env_files_test_tool" ]]
+[[ "$(cat "${TEST_MAIN_REPO_DIR}/env_files_test_tool_data.txt")" == "env_files_test_tool" ]]

--- a/cargo_env/env_files_test_tool.sh
+++ b/cargo_env/env_files_test_tool.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Test fixture for env_files path exports.
+set -euo pipefail
+
+readonly data_runfile="_main/cargo_env/env_files_test_tool_data.txt"
+
+resolve_data_path() {
+    if [[ -n "${RUNFILES_MANIFEST_FILE:-}" ]]; then
+        grep -sm1 "^${data_runfile} " "${RUNFILES_MANIFEST_FILE}" | cut -f2- -d' '
+    else
+        printf '%s\n' "${RUNFILES_DIR}/${data_runfile}"
+    fi
+}
+
+data_path="$(resolve_data_path)"
+readonly data_path
+
+cat "${data_path}"

--- a/cargo_env/env_files_test_tool_data.txt
+++ b/cargo_env/env_files_test_tool_data.txt
@@ -1,0 +1,1 @@
+env_files_test_tool

--- a/cargo_env/env_wrapper.sh
+++ b/cargo_env/env_wrapper.sh
@@ -29,8 +29,15 @@ set -o pipefail
 # but `RUNFILES_DIR` is set correctly.
 #
 # We need this variable because the `export` lines in the ${ENVIRONMENT_PATH} file
-# refer to it.
-RUNFILES_DIR=${RUNFILES_DIR:-${PWD}/..}
+# refer to it. It must be exported so tools from those variables inherit their
+# runfiles environment.
+export RUNFILES_DIR=${RUNFILES_DIR:-${PWD}/..}
+if [[ -n "${RUNFILES_MANIFEST_FILE:-}" ]]; then
+    export RUNFILES_MANIFEST_FILE
+fi
+if [[ -n "${RUNFILES_MANIFEST_ONLY:-}" ]]; then
+    export RUNFILES_MANIFEST_ONLY
+fi
 
 # shellcheck source=/dev/null
 source "$(rlocation "${ENVIRONMENT_PATH}")"


### PR DESCRIPTION
## Summary

Add `env_files` for exporting file/tool paths and `env_directory_subpaths` for exporting subdirectories under `env_directories` targets. Generated environment files use Bazel runfiles paths so exported tools and directories resolve correctly.

## Validation

- `bazel test //cargo_env:env_files_test`
- `bazel test --nobuild_runfile_links //cargo_env:env_files_test`